### PR TITLE
At-least-once delivery guarantee

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ erl_crash.dump
 cainophile-*.tar
 .idea/
 cainophile.iml
+.elixir_ls

--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ Cainophile.Adapters.Postgres.subscribe(Cainophile.ExamplePublisher, self())
 ```
 
 This will asyncronously deliver changes as messages to your process. See Cainophile.Changes for what they'll look like.
+
+## At-least-once delivery guarantee
+
+To provide at-least-once delivery guarantee, the subscription needs to be set up **before** the processor starts receiving the changes. This can be achieved via `:subscribers` option. See [examples](./examples) for more details.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Then, you can subscribe to changes with `Cainophile.Adapters.Postgres.subscribe/
 Cainophile.Adapters.Postgres.subscribe(Cainophile.ExamplePublisher, self())
 ```
 
-This will asyncronously deliver changes as messages to your process. See Cainophile.Changes for what they'll look like.
+This will asynchronously deliver changes as messages to your process. See Cainophile.Changes for what they'll look like.
 
 ## At-least-once delivery guarantee
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,52 @@
+# Examples
+
+## At least once delivery
+
+Use case: 
+* you want your subscription to receive changes which happened while your app is offline
+* if your subscription crashes, you want to re-process the changeset
+ 
+This can be achieved by using `:subscribers` option with a supervised setup:
+
+```elixir
+defmodule ExampleApp.Application do
+  use Application
+
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    children = [
+      {
+        Cainophile.Adapters.Postgres,
+        epgsql: %{ ... },
+        slot: "example", 
+        publications: ["example_publication"],
+        subscribers: [&ExampleApp.Subscription.handle/1]
+      }
+    ]
+
+    opts = [strategy: :one_for_one, name: ExampleApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end
+
+defmodule ExampleApp.Subscription do
+  def handle(_change), do: ...
+end
+```
+
+Or move `child_spec` to [AtLeastOnceSubscription](./at_least_once_subscription.exs) module for a more concise syntax:
+
+```elixir
+defmodule ExampleApp.Application do
+  use Application
+
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    children = [
+       ExampleApp.AtLeastOnceSubscription
+    ]
+
+    opts = [strategy: :one_for_one, name: ExampleApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+```

--- a/examples/at_least_once_subscription.exs
+++ b/examples/at_least_once_subscription.exs
@@ -1,0 +1,33 @@
+defmodule ExampleApp.AtLeastOnceSubscription do
+  def child_spec(_opts) do
+    cainophile_opts = [
+      epgsql: %{
+        host: 'localhost',
+        username: "foo",
+        password: "bar",
+        database: "mydb"
+      },
+      slot: "example",
+      publications: ["example_publication"],
+      # passing the handler upfront to make sure the subscription is already set up
+      # by the time the very first changeset arrives.
+      subscribers: [&handle/1]
+    ]
+
+    %{
+      id: __MODULE__,
+      start: {Cainophile.Adapters.Postgres, :start_link, [cainophile_opts]}
+    }
+  end
+
+  defp handle(change) do
+    if :rand.uniform(2) == 1 do
+      # If an exception happens in this handler, the LSN is not committed back to PG.
+      # The entire process crashes, a supervisor restarts it,
+      # and the changeset is processed one more time ("at least once delivery")
+      raise "Expected error"
+    else
+      IO.inspect(change)
+    end
+  end
+end

--- a/lib/cainophile/adapters/postgres.ex
+++ b/lib/cainophile/adapters/postgres.ex
@@ -54,8 +54,8 @@ defmodule Cainophile.Adapters.Postgres do
   @impl true
   def handle_info({:epgsql, _pid, {:x_log_data, _start_lsn, _end_lsn, binary_msg}}, state) do
     decoded = PgoutputDecoder.decode_message(binary_msg)
-    Logger.debug(fn -> "Received binary message: #{inspect(binary_msg, limit: :infinity)}" end)
-    Logger.debug(fn -> "Decoded message: " <> inspect(decoded, limit: :infinity) end)
+    Logger.debug("Received binary message: #{inspect(binary_msg, limit: :infinity)}")
+    Logger.debug("Decoded message: " <> inspect(decoded, limit: :infinity))
 
     {:noreply, process_message(decoded, state)}
   end
@@ -181,9 +181,9 @@ defmodule Cainophile.Adapters.Postgres do
   end
 
   defp notify_subscribers(%Transaction{} = txn, subscribers) do
-    Logger.debug(fn ->
+    Logger.debug(
       "Notifying subscribers: #{inspect(subscribers)} about transaction: #{inspect(txn)}"
-    end)
+    )
 
     for(sub <- subscribers, is_pid(sub), do: send(sub, txn)) ++
       for sub <- subscribers, is_function(sub), do: sub.(txn)

--- a/lib/cainophile/adapters/postgres.ex
+++ b/lib/cainophile/adapters/postgres.ex
@@ -54,8 +54,8 @@ defmodule Cainophile.Adapters.Postgres do
   @impl true
   def handle_info({:epgsql, _pid, {:x_log_data, _start_lsn, _end_lsn, binary_msg}}, state) do
     decoded = PgoutputDecoder.decode_message(binary_msg)
-    Logger.debug("Received binary message: #{inspect(binary_msg, limit: :infinity)}")
-    Logger.debug("Decoded message: " <> inspect(decoded, limit: :infinity))
+    Logger.debug(fn -> "Received binary message: #{inspect(binary_msg, limit: :infinity)}" end)
+    Logger.debug(fn -> "Decoded message: " <> inspect(decoded, limit: :infinity) end)
 
     {:noreply, process_message(decoded, state)}
   end
@@ -181,9 +181,9 @@ defmodule Cainophile.Adapters.Postgres do
   end
 
   defp notify_subscribers(%Transaction{} = txn, subscribers) do
-    Logger.debug(
+    Logger.debug(fn ->
       "Notifying subscribers: #{inspect(subscribers)} about transaction: #{inspect(txn)}"
-    )
+    end)
 
     for(sub <- subscribers, is_pid(sub), do: send(sub, txn)) ++
       for sub <- subscribers, is_function(sub), do: sub.(txn)

--- a/lib/cainophile/adapters/postgres.ex
+++ b/lib/cainophile/adapters/postgres.ex
@@ -45,7 +45,11 @@ defmodule Cainophile.Adapters.Postgres do
 
   @impl true
   def init(config) do
-    adapter_impl(config).init(config)
+    initial_subscribers = Keyword.get(config, :subscribers, [])
+
+    with {:ok, state} <- adapter_impl(config).init(config) do
+      {:ok, append_subscribers(state, initial_subscribers)}
+    end
   end
 
   @impl true
@@ -188,6 +192,10 @@ defmodule Cainophile.Adapters.Postgres do
 
   defp adapter_impl(config) do
     Keyword.get(config, :postgres_adapter, Cainophile.Adapters.Postgres.EpgsqlImplementation)
+  end
+
+  defp append_subscribers(state, extra_subs) do
+    %{state | subscribers: state.subscribers ++ extra_subs}
   end
 
   # Client

--- a/test/cainophile/adapters/postgres_test.exs
+++ b/test/cainophile/adapters/postgres_test.exs
@@ -96,12 +96,12 @@ defmodule Cainophile.Adapters.PostgresTest do
   end
 
   setup :set_mox_global
-  setup :create_mocks
 
   # Make sure mocks are verified when the test exits
   setup :verify_on_exit!
 
   describe "adding subscriptions (when started without subscribers)" do
+    setup :create_mocks
     setup :start_processor_without_subscribers
 
     test "allows subscribing to changes by pid", %{processor: processor} do
@@ -120,6 +120,8 @@ defmodule Cainophile.Adapters.PostgresTest do
   end
 
   describe "adding subscriptions (when started with predefined subscribers)" do
+    setup :create_mocks
+
     test "allows passing subscriber pid in start_link opts" do
       {:ok, processor} =
         Postgres.start_link(postgres_adapter: PostgresMock, subscribers: [self()])
@@ -147,7 +149,16 @@ defmodule Cainophile.Adapters.PostgresTest do
     end
   end
 
+  describe "subscribers option in start_links" do
+    test "validates values (only pids and functions allowed) " do
+      {:error, _} = Postgres.start_link(postgres_adapter: PostgresMock, subscribers: [nil])
+      {:error, _} = Postgres.start_link(postgres_adapter: PostgresMock, subscribers: ["foo"])
+      {:error, _} = Postgres.start_link(postgres_adapter: PostgresMock, subscribers: [3.14])
+    end
+  end
+
   describe "Change handling" do
+    setup :create_mocks
     setup :start_processor_without_subscribers
 
     setup %{processor: processor} do


### PR DESCRIPTION
**Problems**
1. There may be a gap between starting the processor and subscribing to the changes via `subscribe` call. The changes arrived during this gap will be lost.
2. Whenever a supervised process crashes, the subscription needs to be re-established via `subscribe` call.

**Solution**
Subscribers can be passed right in the child_spec

**Open questions**
* should we support passing **pid** to `:subscribers` option at all? In a supervised scenario, a registered process name (atom or tuple) would make more sense.